### PR TITLE
ダイレクト投稿を除外できるように

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -86,8 +86,8 @@
                                 <summary>プライバシー設定</summary>
                                 
                                 <div class="form-check">
-                                    <label class="form-select-label" for="import_visibility">取得範囲</label>
-                                    <select class="form-select" name="import_visibility" id="import_visibility">
+                                    <label class="form-select-label" for="importVisibility">取得範囲</label>
+                                    <select class="form-select" name="importVisibility" id="importVisibility">
                                         <option value="public_only">公開投稿のみ</option>
                                         <option value="followers">フォロワー限定まで</option>
                                         <option value="direct">ダイレクトまで</option>

--- a/templates/index.html
+++ b/templates/index.html
@@ -86,8 +86,12 @@
                                 <summary>プライバシー設定</summary>
                                 
                                 <div class="form-check">
-                                    <label class="form-check-label" for="noImportPrivatePost">一般公開している投稿のみ取り込む</label>
-                                    <input type="checkbox" name="noImportPrivatePost" id="noImportPrivatePost" class="form-check-input" checked>
+                                    <label class="form-select-label" for="import_visibility">取得範囲</label>
+                                    <select class="form-select" name="import_visibility" id="import_visibility">
+                                        <option value="public_only">公開投稿のみ</option>
+                                        <option value="followers">フォロワー限定まで</option>
+                                        <option value="direct">ダイレクトまで</option>
+                                    </select>
                                 </div>
 
                                 <div class="form-check">

--- a/web.py
+++ b/web.py
@@ -323,7 +323,11 @@ def login_msk_callback():
                                 continue
                         # 'direct'の場合はすべての投稿を含める
                         notes.append(note)
-                job_status[job_id]['progress'] = 20 + ((i/int(userdata_block['notesCount']/100))*60)
+                # 投稿数が極端に少ない場合にゼロ除算を行う場合があるため
+                try:
+                    job_status[job_id]['progress'] = 20 + ((i / (int(userdata_block['notesCount']) / 100)) * 60)
+                except ZeroDivisionError:
+                    job_status[job_id]['progress'] = 25 # Workaround: この場合、代用ロジックを実装するまでもなく所要時間が誤差レベルなので固定値
 
                 # 残り時間計算
                 if took_time_array:

--- a/web.py
+++ b/web.py
@@ -162,10 +162,6 @@ def login():
         session['allowGenerateByOther'] = data.get('allowGenerateByOther', False)
         session['hasModelData'] = False
 
-        print(f'Login request: {data["hostname"]} ({data["type"]})')
-        print(f'Import size: {import_size_str}')
-        print(f'Import visibility: {session["importVisibility"]}')
-
         try:
             mi = Misskey(address=data['hostname'], session=request_session)
         except requests.exceptions.ConnectionError:

--- a/web.py
+++ b/web.py
@@ -327,7 +327,7 @@ def login_msk_callback():
                 try:
                     job_status[job_id]['progress'] = 20 + ((i / (int(userdata_block['notesCount']) / 100)) * 60)
                 except ZeroDivisionError:
-                    job_status[job_id]['progress'] = 25 # Workaround: この場合、代用ロジックを実装するまでもなく所要時間が誤差レベルなので固定値
+                    job_status[job_id]['progress'] = 50 # Workaround: この場合、代用ロジックを実装するまでもなく所要時間が誤差レベルなので固定値
 
                 # 残り時間計算
                 if took_time_array:

--- a/web.py
+++ b/web.py
@@ -162,6 +162,10 @@ def login():
         session['allowGenerateByOther'] = data.get('allowGenerateByOther', False)
         session['hasModelData'] = False
 
+        print(f'Login request: {data["hostname"]} ({data["type"]})')
+        print(f'Import size: {import_size_str}')
+        print(f'Import visibility: {session["import_visibility"]}')
+
         try:
             mi = Misskey(address=data['hostname'], session=request_session)
         except requests.exceptions.ConnectionError:

--- a/web.py
+++ b/web.py
@@ -158,13 +158,13 @@ def login():
         session.permanent = True
         session['hostname'] = data['hostname'].lower()
         session['type'] = data['type']
-        session['import_visibility'] = data.get('import_visibility', 'public_only')
+        session['importVisibility'] = data.get('importVisibility', 'public_only')
         session['allowGenerateByOther'] = data.get('allowGenerateByOther', False)
         session['hasModelData'] = False
 
         print(f'Login request: {data["hostname"]} ({data["type"]})')
         print(f'Import size: {import_size_str}')
-        print(f'Import visibility: {session["import_visibility"]}')
+        print(f'Import visibility: {session["importVisibility"]}')
 
         try:
             mi = Misskey(address=data['hostname'], session=request_session)
@@ -210,7 +210,7 @@ def login():
         session.permanent = True
         session['hostname'] = data['hostname'].lower()
         session['type'] = data['type']
-        session['import_visibility'] = data.get('import_visibility', 'public_only')
+        session['importVisibility'] = data.get('importVisibility', 'public_only')
         session['allowGenerateByOther'] = data.get('allowGenerateByOther', False)
         session['hasModelData'] = False
         
@@ -282,7 +282,7 @@ def login_msk_callback():
             'progress_str': '初期化中です'
         }
 
-        import_visibility = session['import_visibility']
+        importVisibility = session['importVisibility']
         allowGenerateByOther = session['allowGenerateByOther']
 
         def proc(job_id, data):
@@ -315,10 +315,10 @@ def login_msk_callback():
                     # notes.extend(notes_block)
                     for note in notes_block:
                         visibility = note['visibility']
-                        if import_visibility == 'public_only':
+                        if importVisibility == 'public_only':
                             if not (visibility == 'public' or visibility == 'home'):
                                 continue
-                        elif import_visibility == 'followers':
+                        elif importVisibility == 'followers':
                             if visibility == 'specified':
                                 continue
                         # 'direct'の場合はすべての投稿を含める
@@ -437,7 +437,7 @@ def login_msk_callback():
             'thread': None
         }
 
-        import_visibility = session['import_visibility']
+        importVisibility = session['importVisibility']
         allowGenerateByOther = session['allowGenerateByOther']
 
         def proc(job_id, data):
@@ -466,10 +466,10 @@ def login_msk_callback():
             imported_toots = 0
             for toot in toots:
                 visibility = toot['visibility']
-                if import_visibility == 'public_only':
+                if importVisibility == 'public_only':
                     if not (visibility == 'public' or visibility == 'unlisted'):
                         continue
-                elif import_visibility == 'followers':
+                elif importVisibility == 'followers':
                     if visibility == 'direct':
                         continue
                 # 'direct'の場合はすべての投稿を含める


### PR DESCRIPTION
## Why
ついさっき(鍵投稿までのつもりで)公開投稿のみを切って学習させたらダイレクト漏洩しちゃった人がいたので
## Summary
### 公開投稿以外を`フォロワー限定まで`と`ダイレクトまで`に分割
ダイレクトまで意図的に学習させたい人はそういないと思うけれど、この選択肢が存在することでダイレクトが学習されないことがわかりやすくなるので
### プライバシー設定内でプルダウンから投稿範囲を選択する形に
![image](https://github.com/user-attachments/assets/e33ad6d9-204d-48fe-93f3-1d04cecf7655)
### 投稿数が極端に少ないユーザーで処理を行うと`ZeroDivisionError`を吐いて学習できない問題の修正
とりあえずMastodon側で使っている固定値にあわせて50%にするようにした(ロジックを修正したところで100件以下は一瞬で終わるため)
## Tested
- Misskey v12.119.2ベースのインスタンスにおいて
	- 通常のアカウント(`@r_ca@62ki.net`)で
		- 問題なく取り込みと生成ができること
	- テスト用アカウント(`@direct_only@62ki.net`)で
		- `ダイレクトまで`にした際、すべてが取得されること(少なすぎて生成は出来ないものの, 候補として問題なく過去に投稿した単語を含んでいた)
		- `公開投稿のみ`にした際、ダイレクトは取得されないこと(個数にて確認)

[Screencast_20250703_145732.webm](https://github.com/user-attachments/assets/705bf236-b39d-4ec3-bc3e-d68df0c5c8ce)

https://62ki.net/notes/a9qjjy59lb

Mastodonについてはテストしていないけどおそらく動きます　必要なら後でやります